### PR TITLE
Add custom storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,15 +87,16 @@ Per default hypercore uses [random-access-file](https://github.com/random-access
   secretKey: buffer, // optionally pass the corresponding secret key yourself
   storeSecretKey: true, // if false, will not save the secret key
   storageCacheSize: 65536, // the # of entries to keep in the storage system's LRU cache (false or 0 to disable)
-  onwrite: (index, data, peer, cb) // optional hook called before data is written after being verified
+  onwrite: (index, data, peer, cb), // optional hook called before data is written after being verified
                                    // (remember to call cb() at the end of your handler)
-  stats: true // collect network-related statistics,
+  stats: true, // collect network-related statistics,
   // Optionally use custom cryptography for signatures
   crypto: {
     sign (data, secretKey, cb(err, signature)),
     verify (signature, data, key, cb(err, valid))
-  }
-  noiseKeyPair: { publicKey, secretKey } // set a static key pair to use for Noise authentication when replicating
+  },
+  noiseKeyPair: { publicKey, secretKey }, // set a static key pair to use for Noise authentication when replicating
+  storage: new Storage() // optional storage instance with the same API as [`lib/storage.js`](lib/storage.js). Used for implementing a custom storage such as leveldb. Defaults to an instance of [`lib/storage.js`](lib/storage.js), instantiated with the `createStorage` argument.
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -354,6 +354,9 @@ Options include:
   keyPair: { publicKey, secretKey }, // use this keypair for Noise authentication
   onauthenticate (remotePublicKey, done) // hook that can be used to authenticate the remote peer.
                                          // calling done with an error will disallow the peer from connecting to you.
+  onfeedauthenticate (feed, remotePublicKey, done) // hook similar to onauthenticate but called per feed to replicate over a stream of feeds.
+                                                   // calling done with an error will disallow the peer from syncing this particular feed, but the
+                                                   // stream will stay open.
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Hypercore is a secure, distributed append-only log.
 
-Built for sharing large datasets and streams of real time data as part of the [Dat project](https://dat.foundation).
+Built for sharing large datasets and streams of real time data as part of the [Hypercore Protocol](https://hypercore-protocol.org).
 
 ``` sh
 npm install hypercore

--- a/bench/build-comparison-table.js
+++ b/bench/build-comparison-table.js
@@ -1,0 +1,85 @@
+const globby = require('globby')
+const fs = require('fs')
+const fsPromises = fs.promises
+const { format } = require('d3-format')
+
+// Generate a markdown table to compare benchmarks between branches. First write
+// the benchmark results from each branch to a file:
+//
+// ```
+// $ git checkout master
+// $ npm run bench > bench.master.log
+// $ git checkout my-branch
+// $ npm run bench > bench.my-branch.log
+// ```
+//
+// Then generate the table:
+//
+// ```
+// node bench/build-comparison-table.js > bench-comparison-table.md
+// ```
+
+;(async () => {
+  const paths = await globby('branch.*.log')
+
+  const benchmarks = await Promise.all(paths.map(async (filepath) => {
+    const data = await fsPromises.readFile(filepath, 'utf8')
+    const benchmark = parseBenchmarks(data)
+    const [, branch, round] = filepath.match(/^branch\.(.*)\.round-(\d+)/)
+    return {
+      branch: branch === 'master' ? 'before' : 'after',
+      round: Number.parseInt(round),
+      results: benchmark
+    }
+  }))
+  const agg = {}
+
+  for (const { branch, results } of benchmarks) {
+    for (const { name, bytesPerSecond, blocksPerSecond } of results) {
+      agg[name] = agg[name] || {}
+      const result = agg[name][branch] = agg[name][branch] || []
+      result.bytesPerSecond = (result.bytesPerSecond || []).concat(bytesPerSecond)
+      result.blocksPerSecond = (result.blocksPerSecond || []).concat(blocksPerSecond)
+    }
+  }
+
+  const rows = [
+    ['name', 'before', 'after', 'diff'],
+    ['----', '------', '-----', '----']
+  ]
+  for (const [name, { before, after }] of Object.entries(agg)) {
+    const bytesBeforeAvg = avg(before.bytesPerSecond)
+    const bytesAfterAvg = avg(after.bytesPerSecond)
+    const blocksBeforeAvg = avg(before.blocksPerSecond)
+    const blocksAfterAvg = avg(after.blocksPerSecond)
+
+    const bytesDiff = (bytesAfterAvg - bytesBeforeAvg) / bytesBeforeAvg
+    const blocksDiff = (blocksAfterAvg - blocksBeforeAvg) / blocksBeforeAvg
+    rows.push([
+      name,
+      `${format(',')(bytesBeforeAvg)} bytes/s<br/>${format(',')(blocksBeforeAvg)} blocks/s`,
+      `${format(',')(bytesAfterAvg)} bytes/s<br/>${format(',')(blocksAfterAvg)} blocks/s`,
+      `${format('+.2%')(bytesDiff)} bytes/s<br/>${format('+.2%')(blocksDiff)} blocks/s`
+    ])
+  }
+
+  const tableString = rows.map(row => '| ' + row.join(' | ') + ' |').join('\n')
+  process.stdout.write(tableString)
+})()
+
+function avg (arr) {
+  return arr.reduce((acc, val) => acc + val) / arr.length
+}
+
+function parseBenchmarks (string) {
+  return string.split('\n\n')
+    .filter(chunk => chunk.startsWith('> node '))
+    .map(chunk => {
+      const [cmd, bytesResult, blocksResult] = chunk.split('\n')
+      return {
+        name: cmd.replace(/^> node /, '').replace(/\.js$/, ''),
+        bytesPerSecond: Number.parseInt(bytesResult.split(' ')[0]),
+        blocksPerSecond: Number.parseInt(blocksResult.split(' ')[0])
+      }
+    })
+}

--- a/index.js
+++ b/index.js
@@ -1492,8 +1492,7 @@ Feed.prototype._append = function (batch, cb) {
 
   if (!this._indexing) {
     pending++
-    if (dataBatch.length === 1) this._storage.data.write(this.byteLength, dataBatch[0], done)
-    else this._storage.data.write(this.byteLength, Buffer.concat(dataBatch), done)
+    this._storage.putDataBatch(self.length, dataBatch, { byteOffset: this.byteLength }, done)
   }
 
   this._storage.putNodeBatch(nodeOffset, nodeBatch, done)

--- a/index.js
+++ b/index.js
@@ -6,7 +6,6 @@ var flat = require('flat-tree')
 var codecs = require('codecs')
 var batcher = require('atomic-batcher')
 var inherits = require('inherits')
-var raf = require('random-access-file')
 var bitfield = require('./lib/bitfield')
 var sparseBitfield = require('sparse-bitfield')
 var treeIndex = require('./lib/tree-index')
@@ -50,9 +49,6 @@ module.exports = Feed
 function Feed (createStorage, key, opts) {
   if (!(this instanceof Feed)) return new Feed(createStorage, key, opts)
   Nanoresource.call(this)
-
-  if (typeof createStorage === 'string') createStorage = defaultStorage(createStorage)
-  if (typeof createStorage !== 'function') throw new Error('Storage should be a function or string')
 
   if (typeof key === 'string') key = Buffer.from(key, 'hex')
 
@@ -1672,15 +1668,6 @@ function addSize (size, node) {
 
 function isBlock (index) {
   return (index & 1) === 0
-}
-
-function defaultStorage (dir) {
-  return function (name) {
-    try {
-      var lock = name === 'bitfield' ? require('fd-lock') : null
-    } catch (err) {}
-    return raf(name, { directory: dir, lock: lock })
-  }
 }
 
 function toCodec (enc) {

--- a/index.js
+++ b/index.js
@@ -510,8 +510,8 @@ Feed.prototype._open = function (cb) {
         (self._overwrite ? 1 : 0)
       var error = null
 
-      if (shouldWriteKey) self._storage.key.write(0, self.key, done)
       if (shouldWriteSecretKey) self._storage.secretKey.write(0, self.secretKey, done)
+      if (shouldWriteKey) self._storage.writeKey(self.key, done)
 
       if (self._overwrite) {
         self._storage.bitfield.del(32, Infinity, done)
@@ -1374,7 +1374,7 @@ Feed.prototype.finalize = function (cb) {
     this.key = crypto.tree(this._merkle.roots)
     this.discoveryKey = crypto.discoveryKey(this.key)
   }
-  this._storage.key.write(0, this.key, cb)
+  this._storage.writeKey(this.key, cb)
 }
 
 Feed.prototype.append = function (batch, cb) {

--- a/index.js
+++ b/index.js
@@ -275,8 +275,12 @@ Feed.prototype.update = function (opts, cb) {
     if (err) return cb(err)
     if (len === -1) len = self.length + 1
     if (self.length >= len) return cb(null)
-    if (self.writable && !opts.force) return cb(null)
 
+    const ifAvailable = typeof opts.ifAvailable === 'boolean'
+      ? opts.ifAvailable
+      : self._alwaysIfAvailable
+
+    if (ifAvailable && self.writable && !opts.force) return cb(null)
     if (self.writable) cb = self._writeStateReloader(cb)
 
     var w = {
@@ -289,7 +293,7 @@ Feed.prototype.update = function (opts, cb) {
     }
 
     self._waiting.push(w)
-    if (typeof opts.ifAvailable === 'boolean' ? opts.ifAvailable : self._alwaysIfAvailable) self._ifAvailable(w, len)
+    if (ifAvailable) self._ifAvailable(w, len)
     self._updatePeers()
   })
 }

--- a/index.js
+++ b/index.js
@@ -280,7 +280,7 @@ Feed.prototype.update = function (opts, cb) {
       ? opts.ifAvailable
       : self._alwaysIfAvailable
 
-    if (ifAvailable && self.writable && !opts.force) return cb(null)
+    if (ifAvailable && self.writable && !opts.force) return cb(new Error('No update available from peers'))
     if (self.writable) cb = self._writeStateReloader(cb)
 
     var w = {

--- a/index.js
+++ b/index.js
@@ -510,8 +510,8 @@ Feed.prototype._open = function (cb) {
         (self._overwrite ? 1 : 0)
       var error = null
 
-      if (shouldWriteSecretKey) self._storage.secretKey.write(0, self.secretKey, done)
       if (shouldWriteKey) self._storage.writeKey(self.key, done)
+      if (shouldWriteSecretKey) self._storage.writeSecretKey(self.secretKey, done)
 
       if (self._overwrite) {
         self._storage.bitfield.del(32, Infinity, done)

--- a/index.js
+++ b/index.js
@@ -96,7 +96,7 @@ function Feed (createStorage, key, opts) {
   this._storeSecretKey = opts.storeSecretKey !== false
   this._alwaysIfAvailable = !!opts.ifAvailable
   this._merkle = null
-  this._storage = storage(createStorage, opts)
+  this._storage = opts.storage || storage(createStorage, opts)
   this._batch = batcher(this._onwrite ? workHook : work)
 
   this.timeouts = opts.timeouts || {

--- a/index.js
+++ b/index.js
@@ -26,9 +26,12 @@ class Extension extends Message {
   broadcast (message) {
     const feed = this.local.handlers
     const buf = this.encoding.encode(message)
+    let broadcasted = false
     for (const peer of feed.peers) {
+      broadcasted = true
       peer.extension(this.id, buf)
     }
+    return broadcasted
   }
 
   send (message, peer) {

--- a/index.js
+++ b/index.js
@@ -227,9 +227,7 @@ Feed.prototype.replicate = function (initiator, opts) {
   opts.stats = !!this._stats
   opts.noise = !(opts.noise === false && opts.encrypted === false)
 
-  var stream = replicate(this, initiator, opts)
-  this.emit('replicating', stream)
-  return stream
+  return replicate(this, initiator, opts)
 }
 
 Feed.prototype.registerExtension = function (name, handlers) {

--- a/index.js
+++ b/index.js
@@ -275,6 +275,7 @@ Feed.prototype.update = function (opts, cb) {
     if (err) return cb(err)
     if (len === -1) len = self.length + 1
     if (self.length >= len) return cb(null)
+    if (self.writable && !opts.force) return cb(null)
 
     if (self.writable) cb = self._writeStateReloader(cb)
 

--- a/index.js
+++ b/index.js
@@ -514,7 +514,7 @@ Feed.prototype._open = function (cb) {
       if (shouldWriteSecretKey) self._storage.writeSecretKey(self.secretKey, done)
 
       if (self._overwrite) {
-        self._storage.bitfield.del(32, Infinity, done)
+        self._storage.delBitfield(done)
       }
 
       done(null)

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -1,4 +1,5 @@
 // Before hypercore-crypto existed, all of hypercore's crypto operations lived here.
 // This only exists for backwards compatibility with projects that explicitly require this file.
 // Please use the hypercore-crypto package directly instead.
+// https://github.com/mafintosh/hypercore-crypto
 module.exports = require('hypercore-crypto')

--- a/lib/replicate.js
+++ b/lib/replicate.js
@@ -301,6 +301,8 @@ Peer.prototype._onrequesttimeout = function () {
 }
 
 Peer.prototype.onhave = function (have) {
+  this.feed.emit('peer-ack', this, have)
+
   if (this.ack && have.ack && !have.bitfield && this.feed.bitfield.get(have.start)) {
     this.stream.stream.emit('ack', have)
     return

--- a/lib/replicate.js
+++ b/lib/replicate.js
@@ -44,6 +44,7 @@ function replicate (feed, initiator, opts) {
 
     stream.setMaxListeners(0)
     peer.ready()
+    feed.emit('replicating', stream)
   }
 }
 

--- a/lib/replicate.js
+++ b/lib/replicate.js
@@ -30,6 +30,44 @@ function replicate (feed, initiator, opts) {
     if (stream.destroyed) return
     if (stream.opened(feed.key)) return
 
+    if (opts.noise !== false && opts.onfeedauthenticate) {
+      if (!stream.remotePublicKey) {
+        feed.ifAvailable.wait()
+        stream.setMaxListeners(0)
+        stream.on('close', onhandshake)
+        stream.on('handshake', onhandshake)
+        return
+      }
+      feedauthenticate()
+      return
+    }
+    replicatePeer()
+  }
+
+  function onhandshake () {
+    feed.ifAvailable.continue()
+    stream.off('close', onhandshake)
+    stream.off('handshake', onhandshake)
+    feedauthenticate()
+  }
+
+  function feedauthenticate () {
+    if (stream.destroyed) return
+    if (stream.opened(feed.key)) return
+    feed.ifAvailable.wait()
+    opts.onfeedauthenticate(feed, stream.remotePublicKey, function (err) {
+      feed.ifAvailable.continue()
+      if (stream.destroyed) return
+      if (stream.opened(feed.key)) return
+      if (err) {
+        stream.close(feed.discoveryKey)
+        return
+      }
+      replicatePeer()
+    })
+  }
+
+  function replicatePeer () {
     if (opts.noise !== false) {
       if (stream.remoteOpened(feed.key) && !stream.remoteVerified(feed.key)) {
         stream.close(feed.discoveryKey)

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -1,13 +1,17 @@
 var uint64be = require('uint64be')
 var flat = require('flat-tree')
+var raf = require('random-access-file')
 var createCache = require('./cache')
 
 module.exports = Storage
 
 var noarr = []
 
-function Storage (create, opts) {
-  if (!(this instanceof Storage)) return new Storage(create, opts)
+function Storage (createStorage, opts) {
+  if (!(this instanceof Storage)) return new Storage(createStorage, opts)
+
+  if (typeof createStorage === 'string') createStorage = defaultStorage(createStorage)
+  if (typeof createStorage !== 'function') throw new Error('Storage should be a function or string')
 
   const cache = createCache(opts)
 
@@ -19,7 +23,7 @@ function Storage (create, opts) {
   this._data = null
   this._bitfield = null
   this._signatures = null
-  this._create = create
+  this._create = createStorage
 }
 
 Storage.prototype.putData = function (index, data, nodes, cb) {
@@ -483,5 +487,14 @@ function readAll (st, offset, pageSize, cb) {
     if (err) return cb(null, bufs)
     bufs.push(buf)
     st.read(offset + bufs.length * pageSize, pageSize, loop)
+  }
+}
+
+function defaultStorage (dir) {
+  return function (name) {
+    try {
+      var lock = name === 'bitfield' ? require('fd-lock') : null
+    } catch (err) {}
+    return raf(name, { directory: dir, lock: lock })
   }
 }

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -320,7 +320,7 @@ Storage.Node = Node
 function noop () {}
 
 function copyMaybe (buf, maxSize) {
-  if (buf.buffer.byteLength < maxSize) return buf
+  if (buf.buffer.byteLength <= maxSize) return buf
   const cpy = Buffer.alloc(buf.byteLength)
   buf.copy(cpy)
   return cpy

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -47,6 +47,35 @@ Storage.prototype.getData = function (index, cb) {
   })
 }
 
+Storage.prototype.clearData = function (start, end, opts, cb) {
+  if (typeof end === 'function') return this.clearData(start, start + 1, null, end)
+  if (typeof opts === 'function') return this.clearData(start, end, null, opts)
+  if (!opts) opts = {}
+  if (!end) end = start + 1
+  if (!cb) cb = noop
+
+  var self = this
+  var byteOffset = start === 0 ? 0 : (typeof opts.byteOffset === 'number' ? opts.byteOffset : -1)
+  var byteLength = typeof opts.byteLength === 'number' ? opts.byteLength : -1
+
+  if (byteOffset > -1) return onstartbytes(null, byteOffset)
+  this.dataOffset(start, [], onstartbytes)
+
+  function onstartbytes (err, offset) {
+    if (err) return cb(err)
+    byteOffset = offset
+    if (byteLength > -1) return onendbytes(null, byteLength + byteOffset)
+    // TODO: shortcut if (end === self.length)
+    self.dataOffset(end, [], onendbytes)
+  }
+
+  function onendbytes (err, end) {
+    if (err) return cb(err)
+    if (!self.data.del) return cb() // Not all data storage impls del
+    self.data.del(byteOffset, end - byteOffset, cb)
+  }
+}
+
 Storage.prototype.nextSignature = function (index, cb) {
   var self = this
 

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -214,6 +214,10 @@ Storage.prototype.putBitfield = function (offset, data, cb) {
   this.bitfield.write(32 + offset, data, cb)
 }
 
+Storage.prototype.delBitfield = function (cb) {
+  this.bitfield.del(32, Infinity, cb)
+}
+
 Storage.prototype.close = function (cb) {
   if (!cb) cb = noop
   var missing = 6

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -258,6 +258,10 @@ Storage.prototype.openKey = function (opts, cb) {
   this.key.read(0, 32, cb)
 }
 
+Storage.prototype.writeKey = function (key, cb) {
+  this.key.write(0, key, cb)
+}
+
 Storage.prototype.open = function (opts, cb) {
   if (typeof opts === 'function') return this.open({}, opts)
 

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -33,6 +33,38 @@ Storage.prototype.putData = function (index, data, nodes, cb) {
   })
 }
 
+/**
+ * @param {number} index
+ * @param {Buffer[]} dataBatch
+ * @param {object} [opts]
+ * @param {number} [opts.byteOffset] If known, byteOffset of index, to avoid recalculation
+ * @param {Node[]} [opts.cachedNodes] Cached nodes to speed up calculation of byteOffset of index
+ */
+Storage.prototype.putDataBatch = function (index, dataBatch, opts, cb) {
+  if (typeof cb === 'undefined' && typeof opts === 'function') {
+    cb = opts
+    opts = {}
+  }
+  opts = opts || {}
+  var self = this
+  var cachedNodes = opts.cachedNodes || []
+
+  if (typeof opts.byteOffset === 'number') {
+    onOffset(null, opts.byteOffset)
+  } else {
+    this.dataOffset(index, cachedNodes, onOffset)
+  }
+
+  function onOffset (err, offset) {
+    if (err) return cb(err)
+    if (dataBatch.length === 1) {
+      self.data.write(offset, dataBatch[0], cb)
+    } else {
+      self.data.write(offset, Buffer.concat(dataBatch), cb)
+    }
+  }
+}
+
 Storage.prototype.getData = function (index, cb) {
   var self = this
   var cached = this.dataCache && this.dataCache.get(index)

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -174,7 +174,7 @@ Storage.prototype.getNode = function (index, cb) {
 
     if (!size && isBlank(hash)) return cb(new Error('No node found'))
 
-    var val = new Node(index, hash, size, null)
+    var val = new Node(index, self.treeCache ? copyMaybe(hash, 40) : hash, size, null)
     if (self.treeCache) self.treeCache.set(index, val)
     cb(null, val)
   })
@@ -318,6 +318,13 @@ Storage.prototype.open = function (opts, cb) {
 Storage.Node = Node
 
 function noop () {}
+
+function copyMaybe (buf, maxSize) {
+  if (buf.buffer.byteLength < maxSize) return buf
+  const cpy = Buffer.alloc(buf.byteLength)
+  buf.copy(cpy)
+  return cpy
+}
 
 function header (type, size, name) {
   var buf = Buffer.alloc(32)

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -26,7 +26,7 @@ Storage.prototype.putData = function (index, data, nodes, cb) {
   if (!cb) cb = noop
   var self = this
   if (!data.length) return cb(null)
-  this.dataOffset(index, nodes, function (err, offset, size) {
+  this._dataOffset(index, nodes, function (err, offset, size) {
     if (err) return cb(err)
     if (size !== data.length) return cb(new Error('Unexpected data size'))
     self.data.write(offset, data, cb)
@@ -52,7 +52,7 @@ Storage.prototype.putDataBatch = function (index, dataBatch, opts, cb) {
   if (typeof opts.byteOffset === 'number') {
     onOffset(null, opts.byteOffset)
   } else {
-    this.dataOffset(index, cachedNodes, onOffset)
+    this._dataOffset(index, cachedNodes, onOffset)
   }
 
   function onOffset (err, offset) {
@@ -69,7 +69,7 @@ Storage.prototype.getData = function (index, cb) {
   var self = this
   var cached = this.dataCache && this.dataCache.get(index)
   if (cached) return process.nextTick(cb, null, cached)
-  this.dataOffset(index, noarr, function (err, offset, size) {
+  this._dataOffset(index, noarr, function (err, offset, size) {
     if (err) return cb(err)
     self.data.read(offset, size, (err, data) => {
       if (err) return cb(err)
@@ -91,14 +91,14 @@ Storage.prototype.clearData = function (start, end, opts, cb) {
   var byteLength = typeof opts.byteLength === 'number' ? opts.byteLength : -1
 
   if (byteOffset > -1) return onstartbytes(null, byteOffset)
-  this.dataOffset(start, [], onstartbytes)
+  this._dataOffset(start, [], onstartbytes)
 
   function onstartbytes (err, offset) {
     if (err) return cb(err)
     byteOffset = offset
     if (byteLength > -1) return onendbytes(null, byteLength + byteOffset)
     // TODO: shortcut if (end === self.length)
-    self.dataOffset(end, [], onendbytes)
+    self._dataOffset(end, [], onendbytes)
   }
 
   function onendbytes (err, end) {
@@ -139,7 +139,7 @@ Storage.prototype.deleteSignatures = function (start, end, cb) {
   this.signatures.del(32 + 64 * start, (end - start) * 64, cb)
 }
 
-Storage.prototype.dataOffset = function (index, cachedNodes, cb) {
+Storage.prototype._dataOffset = function (index, cachedNodes, cb) {
   var roots = flat.fullRoots(2 * index)
   var self = this
   var offset = 0
@@ -183,7 +183,7 @@ Storage.prototype.getDataBatch = function (start, n, cb) {
   var sizes = new Array(n)
   var self = this
 
-  this.dataOffset(start, noarr, function (err, offset, size) {
+  this._dataOffset(start, noarr, function (err, offset, size) {
     if (err) return cb(err)
 
     start++

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -13,13 +13,13 @@ function Storage (create, opts) {
 
   this.treeCache = cache.tree || null
   this.dataCache = cache.data || null
-  this.key = null
-  this.secretKey = null
-  this.tree = null
-  this.data = null
-  this.bitfield = null
-  this.signatures = null
-  this.create = create
+  this._key = null
+  this._secretKey = null
+  this._tree = null
+  this._data = null
+  this._bitfield = null
+  this._signatures = null
+  this._create = create
 }
 
 Storage.prototype.putData = function (index, data, nodes, cb) {
@@ -29,7 +29,7 @@ Storage.prototype.putData = function (index, data, nodes, cb) {
   this._dataOffset(index, nodes, function (err, offset, size) {
     if (err) return cb(err)
     if (size !== data.length) return cb(new Error('Unexpected data size'))
-    self.data.write(offset, data, cb)
+    self._data.write(offset, data, cb)
   })
 }
 
@@ -58,9 +58,9 @@ Storage.prototype.putDataBatch = function (index, dataBatch, opts, cb) {
   function onOffset (err, offset) {
     if (err) return cb(err)
     if (dataBatch.length === 1) {
-      self.data.write(offset, dataBatch[0], cb)
+      self._data.write(offset, dataBatch[0], cb)
     } else {
-      self.data.write(offset, Buffer.concat(dataBatch), cb)
+      self._data.write(offset, Buffer.concat(dataBatch), cb)
     }
   }
 }
@@ -71,7 +71,7 @@ Storage.prototype.getData = function (index, cb) {
   if (cached) return process.nextTick(cb, null, cached)
   this._dataOffset(index, noarr, function (err, offset, size) {
     if (err) return cb(err)
-    self.data.read(offset, size, (err, data) => {
+    self._data.read(offset, size, (err, data) => {
       if (err) return cb(err)
       if (self.dataCache) self.dataCache.set(index, data)
       return cb(null, data)
@@ -103,8 +103,8 @@ Storage.prototype.clearData = function (start, end, opts, cb) {
 
   function onendbytes (err, end) {
     if (err) return cb(err)
-    if (!self.data.del) return cb() // Not all data storage impls del
-    self.data.del(byteOffset, end - byteOffset, cb)
+    if (!self._data.del) return cb() // Not all data storage impls del
+    self._data.del(byteOffset, end - byteOffset, cb)
   }
 }
 
@@ -128,15 +128,15 @@ Storage.prototype.getSignature = function (index, cb) {
 
 // Caching not enabled for signatures because they are rarely reused.
 Storage.prototype._getSignature = function (index, cb) {
-  this.signatures.read(32 + 64 * index, 64, cb)
+  this._signatures.read(32 + 64 * index, 64, cb)
 }
 
 Storage.prototype.putSignature = function (index, signature, cb) {
-  this.signatures.write(32 + 64 * index, signature, cb)
+  this._signatures.write(32 + 64 * index, signature, cb)
 }
 
 Storage.prototype.deleteSignatures = function (start, end, cb) {
-  this.signatures.del(32 + 64 * start, (end - start) * 64, cb)
+  this._signatures.del(32 + 64 * start, (end - start) * 64, cb)
 }
 
 Storage.prototype._dataOffset = function (index, cachedNodes, cb) {
@@ -190,7 +190,7 @@ Storage.prototype.getDataBatch = function (start, n, cb) {
     n--
 
     if (n <= 0) return ontree(null, null)
-    self.tree.read(32 + 80 * start, 80 * n - 40, ontree)
+    self._tree.read(32 + 80 * start, 80 * n - 40, ontree)
 
     function ontree (err, buf) {
       if (err) return cb(err)
@@ -204,7 +204,7 @@ Storage.prototype.getDataBatch = function (start, n, cb) {
         }
       }
 
-      self.data.read(offset, total, ondata)
+      self._data.read(offset, total, ondata)
     }
 
     function ondata (err, buf) {
@@ -227,7 +227,7 @@ Storage.prototype.getNode = function (index, cb) {
 
   var self = this
 
-  this.tree.read(32 + 40 * index, 40, function (err, buf) {
+  this._tree.read(32 + 40 * index, 40, function (err, buf) {
     if (err) return cb(err)
 
     var hash = buf.slice(0, 32)
@@ -254,7 +254,7 @@ Storage.prototype.putNodeBatch = function (index, nodes, cb) {
     uint64be.encode(node.size, buf, 32 + offset)
   }
 
-  this.tree.write(32 + 40 * index, buf, cb)
+  this._tree.write(32 + 40 * index, buf, cb)
 }
 
 Storage.prototype.putNode = function (index, node, cb) {
@@ -268,15 +268,15 @@ Storage.prototype.putNode = function (index, node, cb) {
 
   node.hash.copy(buf, 0)
   uint64be.encode(node.size, buf, 32)
-  this.tree.write(32 + 40 * index, buf, cb)
+  this._tree.write(32 + 40 * index, buf, cb)
 }
 
 Storage.prototype.putBitfield = function (offset, data, cb) {
-  this.bitfield.write(32 + offset, data, cb)
+  this._bitfield.write(32 + offset, data, cb)
 }
 
 Storage.prototype.delBitfield = function (cb) {
-  this.bitfield.del(32, Infinity, cb)
+  this._bitfield.del(32, Infinity, cb)
 }
 
 Storage.prototype.close = function (cb) {
@@ -284,12 +284,12 @@ Storage.prototype.close = function (cb) {
   var missing = 6
   var error = null
 
-  close(this.bitfield, done)
-  close(this.tree, done)
-  close(this.data, done)
-  close(this.key, done)
-  close(this.secretKey, done)
-  close(this.signatures, done)
+  close(this._bitfield, done)
+  close(this._tree, done)
+  close(this._data, done)
+  close(this._key, done)
+  close(this._secretKey, done)
+  close(this._signatures, done)
 
   function done (err) {
     if (err) error = err
@@ -303,12 +303,12 @@ Storage.prototype.destroy = function (cb) {
   var missing = 6
   var error = null
 
-  destroy(this.bitfield, done)
-  destroy(this.tree, done)
-  destroy(this.data, done)
-  destroy(this.key, done)
-  destroy(this.secretKey, done)
-  destroy(this.signatures, done)
+  destroy(this._bitfield, done)
+  destroy(this._tree, done)
+  destroy(this._data, done)
+  destroy(this._key, done)
+  destroy(this._secretKey, done)
+  destroy(this._signatures, done)
 
   function done (err) {
     if (err) error = err
@@ -319,16 +319,16 @@ Storage.prototype.destroy = function (cb) {
 
 Storage.prototype.openKey = function (opts, cb) {
   if (typeof opts === 'function') return this.openKey({}, opts)
-  if (!this.key) this.key = this.create('key', opts)
-  this.key.read(0, 32, cb)
+  if (!this._key) this._key = this._create('key', opts)
+  this._key.read(0, 32, cb)
 }
 
 Storage.prototype.writeKey = function (key, cb) {
-  this.key.write(0, key, cb)
+  this._key.write(0, key, cb)
 }
 
 Storage.prototype.writeSecretKey = function (key, cb) {
-  this.secretKey.write(0, key, cb)
+  this._secretKey.write(0, key, cb)
 }
 
 Storage.prototype.open = function (opts, cb) {
@@ -338,12 +338,12 @@ Storage.prototype.open = function (opts, cb) {
   var error = null
   var missing = 5
 
-  if (!this.key) this.key = this.create('key', opts)
-  if (!this.secretKey) this.secretKey = this.create('secret_key', opts)
-  if (!this.tree) this.tree = this.create('tree', opts)
-  if (!this.data) this.data = this.create('data', opts)
-  if (!this.bitfield) this.bitfield = this.create('bitfield', opts)
-  if (!this.signatures) this.signatures = this.create('signatures', opts)
+  if (!this._key) this._key = this._create('key', opts)
+  if (!this._secretKey) this._secretKey = this._create('secret_key', opts)
+  if (!this._tree) this._tree = this._create('tree', opts)
+  if (!this._data) this._data = this._create('data', opts)
+  if (!this._bitfield) this._bitfield = this._create('bitfield', opts)
+  if (!this._signatures) this._signatures = this._create('signatures', opts)
 
   var result = {
     bitfield: [],
@@ -352,30 +352,30 @@ Storage.prototype.open = function (opts, cb) {
     key: null
   }
 
-  this.bitfield.read(0, 32, function (err, h) {
+  this._bitfield.read(0, 32, function (err, h) {
     if (err && err.code === 'ELOCKED') return cb(err)
     if (h) result.bitfieldPageSize = h.readUInt16BE(5)
-    self.bitfield.write(0, header(0, result.bitfieldPageSize, null), function (err) {
+    self._bitfield.write(0, header(0, result.bitfieldPageSize, null), function (err) {
       if (err) return cb(err)
-      readAll(self.bitfield, 32, result.bitfieldPageSize, function (err, pages) {
+      readAll(self._bitfield, 32, result.bitfieldPageSize, function (err, pages) {
         if (pages) result.bitfield = pages
         done(err)
       })
     })
   })
 
-  this.signatures.write(0, header(1, 64, 'Ed25519'), done)
-  this.tree.write(0, header(2, 40, 'BLAKE2b'), done)
+  this._signatures.write(0, header(1, 64, 'Ed25519'), done)
+  this._tree.write(0, header(2, 40, 'BLAKE2b'), done)
 
   // TODO: Improve the error handling here.
   // I.e. if secretKey length === 64 and it fails, error
 
-  this.secretKey.read(0, 64, function (_, data) {
+  this._secretKey.read(0, 64, function (_, data) {
     if (data) result.secretKey = data
     done(null)
   })
 
-  this.key.read(0, 32, function (_, data) {
+  this._key.read(0, 32, function (_, data) {
     if (data) result.key = data
     done(null)
   })

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -262,6 +262,10 @@ Storage.prototype.writeKey = function (key, cb) {
   this.key.write(0, key, cb)
 }
 
+Storage.prototype.writeSecretKey = function (key, cb) {
+  this.secretKey.write(0, key, cb)
+}
+
 Storage.prototype.open = function (opts, cb) {
   if (typeof opts === 'function') return this.open({}, opts)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hypercore",
-  "version": "9.7.1",
+  "version": "9.7.2",
   "description": "Hypercore is a secure, distributed append-only log",
   "main": "index.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hypercore",
-  "version": "9.7.0",
+  "version": "9.7.1",
   "description": "Hypercore is a secure, distributed append-only log",
   "main": "index.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "flat-tree": "^1.6.0",
     "hypercore-cache": "^1.0.1",
     "hypercore-crypto": "^2.0.0",
-    "hypercore-default-storage": "^1.1.0",
+    "hypercore-default-storage": "^1.1.1",
     "hypercore-protocol": "^8.0.5",
     "hypercore-streams": "^1.0.1",
     "inherits": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
   },
   "devDependencies": {
     "buffer-from": "^1.1.1",
+    "d3-format": "^2.0.0",
+    "globby": "^11.0.1",
     "nyc": "^14.1.1",
     "random-access-memory": "^3.1.0",
     "shuffle-array": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "flat-tree": "^1.6.0",
     "hypercore-cache": "^1.0.1",
     "hypercore-crypto": "^2.0.0",
+    "hypercore-default-storage": "^1.0.2",
     "hypercore-protocol": "^8.0.5",
     "hypercore-streams": "^1.0.1",
     "inherits": "^2.0.3",
@@ -22,7 +23,6 @@
     "nanoguard": "^1.2.0",
     "nanoresource": "^1.3.0",
     "pretty-hash": "^1.0.1",
-    "random-access-file": "^2.1.0",
     "sparse-bitfield": "^3.0.0",
     "timeout-refresh": "^1.0.3",
     "uint64be": "^2.0.1",
@@ -38,12 +38,6 @@
     "standard": "^14.3.4",
     "stream-collector": "^1.0.1",
     "tape": "^4.6.3"
-  },
-  "optionalDependencies": {
-    "fd-lock": "^1.0.2"
-  },
-  "browser": {
-    "fd-lock": false
   },
   "scripts": {
     "test": "standard && tape test/*.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hypercore",
-  "version": "9.7.2",
+  "version": "9.7.3",
   "description": "Hypercore is a secure, distributed append-only log",
   "main": "index.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hypercore",
-  "version": "9.7.4",
+  "version": "9.7.5",
   "description": "Hypercore is a secure, distributed append-only log",
   "main": "index.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hypercore",
-  "version": "9.9.1",
+  "version": "9.10.0",
   "description": "Hypercore is a secure, distributed append-only log",
   "main": "index.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hypercore",
-  "version": "9.7.5",
+  "version": "9.8.0",
   "description": "Hypercore is a secure, distributed append-only log",
   "main": "index.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hypercore",
-  "version": "9.9.0",
+  "version": "9.9.1",
   "description": "Hypercore is a secure, distributed append-only log",
   "main": "index.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "flat-tree": "^1.6.0",
     "hypercore-cache": "^1.0.1",
     "hypercore-crypto": "^2.0.0",
-    "hypercore-default-storage": "^1.0.2",
+    "hypercore-default-storage": "^1.1.0",
     "hypercore-protocol": "^8.0.5",
     "hypercore-streams": "^1.0.1",
     "inherits": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hypercore",
-  "version": "9.7.3",
+  "version": "9.7.4",
   "description": "Hypercore is a secure, distributed append-only log",
   "main": "index.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hypercore",
-  "version": "9.6.0",
+  "version": "9.7.0",
   "description": "Hypercore is a secure, distributed append-only log",
   "main": "index.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hypercore",
-  "version": "9.8.0",
+  "version": "9.9.0",
   "description": "Hypercore is a secure, distributed append-only log",
   "main": "index.js",
   "dependencies": {

--- a/test/audit.js
+++ b/test/audit.js
@@ -19,7 +19,8 @@ tape('basic audit with bad data', function (t) {
 
   feed.append('hello')
   feed.append('world', function () {
-    feed._storage.data.write(0, Buffer.from('H'), function () {
+    // NOTE: Uses internal API of storage to add bad data
+    feed._storage._data.write(0, Buffer.from('H'), function () {
       t.ok(feed.has(0))
       feed.audit(function (err, report) {
         t.error(err, 'no error')

--- a/test/replicate.js
+++ b/test/replicate.js
@@ -813,6 +813,43 @@ tape('double replicate', function (t) {
   })
 })
 
+tape('events: replicating events fired (normal)', function (t) {
+  var feed = create()
+  t.plan(1)
+  feed.on('replicating', () => {
+    t.pass('replicating')
+  })
+  feed.replicate(true).on('end', function () {
+    t.end()
+  })
+})
+
+tape('events: replicating events once for multiple feeds', function (t) {
+  var feed = create()
+  var stream = new Protocol(true)
+  t.plan(1)
+  feed.on('replicating', () => {
+    t.pass('replicating')
+  })
+  feed.replicate(stream)
+  feed.replicate(stream)
+  feed.on('end', function () {
+    t.end()
+  })
+})
+
+tape('events: replicating events not fired if canceled before ready', function (t) {
+  var feed = create()
+  var stream = new Protocol(true)
+  t.plan(0)
+  feed.on('replicating', () => {
+    t.pass('replicating')
+  })
+  stream.destroy()
+  feed.replicate(stream, { live: true })
+  t.end()
+})
+
 tape('regression: replicate without timeout', function (t) {
   t.plan(10)
 


### PR DESCRIPTION
This is a proof-of-concept to see whether Hypercore could support alternative storage to [`random-access-storage`](https://github.com/random-access-storage/random-access-storage).

This PR cleans up the API of the internal [`Storage`](https://github.com/hypercore-protocol/hypercore/blob/master/lib/storage.js) class so that the main hypercore does not reach into the internals of the storage API, then it adds an `opts.storage` option for passing an instance of a custom storage class that implements the same API as the default storage.

NB. This is _not_ the same as `opts.createStorage`, which refers to the instance of [`random-access-storage`](https://github.com/random-access-storage/random-access-storage) used by the `Storage` class. This is for overriding the whole storage with something other than random-access-storage.

### How to implement custom storage?

See [`hypercore-storage-level`](https://github.com/gmaclennan/hypercore-storage-level) as an example storage implemented on a leveldb database.

### Why?

1. **Limited file descriptors**

    Hypercore opens 6 random-access-storage instances, which each leave open a file descriptor. With multiple hypercores open (e.g. for [`multifeed`](https://github.com/kappa-db/multifeed) this can quickly add up to a lot of file descriptors. Android is limited to 1024 FDs per app, and some devices limit to 512, so 86 hypercores would exceed this limit. This is quite possible if each device in a project had 2 hypercores and 50 people are participating.

2. **Server storage**

    For storing Hypercore data online, being tied to random-access-storage requires storage to be on an attached disk. Allowing alternate storage would allow data to be stored in an external database, or object storage such as S3.

3. **Recovering space**

    Currently, using sparse files means that you only use disk space for the hypercore blocks that you have downloaded. However, clearing these blocks does not recover disk space (see https://github.com/mafintosh/fsctl/tree/punchhole for WIP to add native "punchhole" functionality to clear a sparse file and recover disk space). Implementing a custom storage, such as a key-value store, allows disk space to be recovered when blocks are cleared.

### Progress

- [x] **Isolated existing storage module**. Currently hypercore reaches down into the internals of the storage module. Better isolation allows a stable public API for the storage module.
- [x] **Create a proof-of-concept leveldb storage**. For performance reasons it might be better to keep some storage (e.g. bitfield and tree) as random-access storage, but for the initial POC it's using all leveldb.
- [x] **Get tests passing**. Some of the tests reach down into storage internals, so they need to be modified.
    - [x] `test/ack.js`
    - [x] `test/audit.js`
    - [x] `test/basic.js`
    - [x] `test/bitfield.js`
    - [x] `test/cache.js`
    - [x] `test/compat.js`
    - [x] `test/copy.js`
    - [x] `test/default-storage.js`
    - [x] `test/extensions.js`
    - [x] `test/get.js`
    - [x] `test/head.js`
    - [x] `test/replicate.js`
    - [x] `test/seek.js`
    - [x] `test/selections.js`
    - [x] `test/set-uploading-downloading.js`
    - [x] `test/stats.js`
    - [x] `test/streams.js`
    - [x] `test/timeouts.js`
    - [x] `test/tree-index.js`
    - [x] `test/update.js`
    - [x] `test/value-encoding.js`
- [x] Compare benchmarks

| name | before | after | diff |
| ---- | ------ | ----- | ---- |
| write-16kb-blocks | 424,190,256.5 bytes/s<br/>25,848.5 blocks/s | 466,974,804 bytes/s<br/>28,451.5 blocks/s | +10.09% bytes/s<br/>+10.07% blocks/s |
| write-512b-blocks | 86,212,180 bytes/s<br/>168,270 blocks/s | 93,890,196.5 bytes/s<br/>183,036.5 blocks/s | +8.91% bytes/s<br/>+8.78% blocks/s |
| write-64kb-blocks-static | 480,225,178.5 bytes/s<br/>7,321.5 blocks/s | 574,492,573.5 bytes/s<br/>8,759 blocks/s | +19.63% bytes/s<br/>+19.63% blocks/s |
| write-64kb-blocks | 562,612,561.5 bytes/s<br/>8,579.5 blocks/s | 587,978,202 bytes/s<br/>8,961.5 blocks/s | +4.51% bytes/s<br/>+4.45% blocks/s |
| copy-64kb-blocks | 201,904,084.5 bytes/s<br/>3,079 blocks/s | 197,786,239.5 bytes/s<br/>3,017 blocks/s | −2.04% bytes/s<br/>−2.01% blocks/s |
| read-16kb-blocks-proof | 87,754,520.5 bytes/s<br/>5,353.5 blocks/s | 86,934,623.5 bytes/s<br/>5,304 blocks/s | −0.93% bytes/s<br/>−0.92% blocks/s |
| read-16kb-blocks | 752,987,961.5 bytes/s<br/>45,829.5 blocks/s | 746,022,450 bytes/s<br/>45,407 blocks/s | −0.93% bytes/s<br/>−0.92% blocks/s |
| read-512b-blocks | 30,838,337 bytes/s<br/>60,195 blocks/s | 27,954,788 bytes/s<br/>54,569.5 blocks/s | −9.35% bytes/s<br/>−9.35% blocks/s |
| read-64kb-blocks-linear | 742,988,910 bytes/s<br/>11,325 blocks/s | 729,064,189.5 bytes/s<br/>11,116.5 blocks/s | −1.87% bytes/s<br/>−1.84% blocks/s |
| read-64kb-blocks-linear-batch | 764,733,821.5 bytes/s<br/>11,660 blocks/s | 764,505,868 bytes/s<br/>11,652.5 blocks/s | −0.03% bytes/s<br/>−0.06% blocks/s |
| read-64kb-blocks-proof | 327,416,622.5 bytes/s<br/>4,994 blocks/s | 328,411,637.5 bytes/s<br/>5,009 blocks/s | +0.30% bytes/s<br/>+0.30% blocks/s |
| read-64kb-blocks | 2,253,693,382 bytes/s<br/>34,281 blocks/s | 2,344,202,361 bytes/s<br/>35,613.5 blocks/s | +4.02% bytes/s<br/>+3.89% blocks/s |
| replicate-16kb-blocks | 116,052,052 bytes/s<br/>7,079.5 blocks/s | 117,083,592.5 bytes/s<br/>7,141 blocks/s | +0.89% bytes/s<br/>+0.87% blocks/s |
| replicate-64kb-blocks | 236,482,000.5 bytes/s<br/>3,607 blocks/s | 230,973,616.5 bytes/s<br/>3,522 blocks/s | −2.33% bytes/s<br/>−2.36% blocks/s |